### PR TITLE
Added script to install all cocoapods

### DIFF
--- a/install_all_pods.sh
+++ b/install_all_pods.sh
@@ -1,0 +1,10 @@
+dirs=$(find . -name Podfile -print0 | xargs -0 -n1 dirname | sort --unique)
+
+top=$(pwd)
+
+for dir in $dirs
+do
+    cd "$dir"
+    pod install
+    cd "$top"
+done


### PR DESCRIPTION
This script finds all directories containing a `Podfile`. It then loops through the directories and runs `pod install` on each directory.

This is helpful for people who want to look at many of the samples without having to manually install all of the pods.