### PR TITLE
Fix a compile error in 'Material/Programmatic/Button' example

### DIFF
--- a/Material/Programmatic/Button/Button/ViewController.swift
+++ b/Material/Programmatic/Button/Button/ViewController.swift
@@ -35,7 +35,6 @@ struct ButtonLayout {
     struct Flat {
         static let width: CGFloat = 120
         static let height: CGFloat = 44
-        @IBOutlet weak var contentView: UIImageView!
         static let offsetY: CGFloat = -150
     }
     


### PR DESCRIPTION
> ViewController.swift:38:9: Only instance properties can be declared @IBOutlet

delete `@IBOutlet`, and run.