### PR TITLE
Remove erroneous line

### DIFF
--- a/Projects/Programmatic/CollectionView/Podfile
+++ b/Projects/Programmatic/CollectionView/Podfile
@@ -1,11 +1,7 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
-<<<<<<< HEAD
-target ‘CollectionView’ do
-=======
 target 'CollectionView' do
->>>>>>> master
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
 


### PR DESCRIPTION
Fixed an issue that a `[!] Invalid Podfile file: syntax error, unexpected <<` error occurred while executing `./install_all_pods.sh`.